### PR TITLE
Fix theme provider type error

### DIFF
--- a/providers/theme-provider.tsx
+++ b/providers/theme-provider.tsx
@@ -1,14 +1,15 @@
 'use client'
 
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import type { ThemeProviderProps as NextThemesProviderProps } from 'next-themes'
 import type { ReactNode } from 'react'
 
 interface ThemeProviderProps {
   children: ReactNode
-  attribute?: string
-  defaultTheme?: string
-  enableSystem?: boolean
-  disableTransitionOnChange?: boolean
+  attribute?: NextThemesProviderProps['attribute']
+  defaultTheme?: NextThemesProviderProps['defaultTheme']
+  enableSystem?: NextThemesProviderProps['enableSystem']
+  disableTransitionOnChange?: NextThemesProviderProps['disableTransitionOnChange']
 }
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {


### PR DESCRIPTION
Correct `ThemeProviderProps` type definition to align with `next-themes` to fix build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a0a1188-7cbb-4934-a9ee-8d16973f564d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a0a1188-7cbb-4934-a9ee-8d16973f564d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

